### PR TITLE
Add JWKS URLto bypass metadata discovery

### DIFF
--- a/extension/oidcauthextension/README.md
+++ b/extension/oidcauthextension/README.md
@@ -34,7 +34,7 @@ service:
       exporters: [logging]
 ```
 
-Firebase AppCheck is an example service that both uses custom headers and doesn't provide an auto-discovery mechanism:
+Firebase AppCheck is an example service that uses custom headers, doesn't provide an auto-discovery mechanism and has an `issuer_url` that isn't simply the base URL of the JWKS URL.
 
 ```yaml
 extensions:

--- a/extension/oidcauthextension/README.md
+++ b/extension/oidcauthextension/README.md
@@ -33,3 +33,15 @@ service:
       processors: []
       exporters: [logging]
 ```
+
+Firebase AppCheck is an example service that both uses custom headers and doesn't provide an auto-discovery mechanism:
+
+```yaml
+extensions:
+  oidc:
+    issuer_url: https://firebaseappcheck.googleapis.com/<PROJECT_NUMBER>
+    jwks_url: https://firebaseappcheck.googleapis.com/v1/jwks
+    attribute: X-Firebase-AppCheck
+    audience: projects/<PROJECT_NUMBER>
+...
+```

--- a/extension/oidcauthextension/config.go
+++ b/extension/oidcauthextension/config.go
@@ -20,12 +20,17 @@ import "go.opentelemetry.io/collector/config"
 type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
-	// The attribute (header name) to look for auth data. Optional, default value: "authorization".
+	// The attribute (header name) to look for auth data.
+	// Optional, default value: "authorization".
 	Attribute string `mapstructure:"attribute"`
 
 	// IssuerURL is the base URL for the OIDC provider.
 	// Required.
 	IssuerURL string `mapstructure:"issuer_url"`
+
+	// JWKSURL is the URL of the JWKS. Will disable auto-discovery from the Issuer URL.
+	// Optional.
+	JWKSURL string `mapstructure:"jwks_url"`
 
 	// Audience of the token, used during the verification.
 	// For example: "https://accounts.google.com" or "https://login.salesforce.com".

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -118,11 +118,11 @@ func TestOIDCProviderForConfigWithTLS(t *testing.T) {
 	}
 
 	// test
-	provider, err := getProviderForConfig(config)
+	verifier, err := getVerifierForConfig(config)
 
 	// verify
 	assert.NoError(t, err)
-	assert.NotNil(t, provider)
+	assert.NotNil(t, verifier)
 }
 
 func TestOIDCLoadIssuerCAFromPath(t *testing.T) {
@@ -191,11 +191,11 @@ func TestOIDCFailedToLoadIssuerCAFromPathInvalidContent(t *testing.T) {
 	}
 
 	// test
-	provider, err := getProviderForConfig(config) // cross test with getIssuerCACertFromPath
+	verifier, err := getVerifierForConfig(config) // cross test with getIssuerCACertFromPath
 
 	// verify
 	assert.Error(t, err)
-	assert.Nil(t, provider)
+	assert.Nil(t, verifier)
 }
 
 func TestOIDCInvalidAuthHeader(t *testing.T) {

--- a/unreleased/oidcauthextenstion-direct-jwks.yaml
+++ b/unreleased/oidcauthextenstion-direct-jwks.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oidcaithextention
+
+# A brief description of the change
+note: Add support by direct JWKS URL for services without auto-discovery.
+
+# One or more tracking issues related to the change
+issues: []


### PR DESCRIPTION
**Description:**
Some OIDC providers do not support metadata discovery and need the JWKS to be specified directly.

Adds a new parameter `jwks_url` to the `oidcauthextension` config which will be used in favour of auto-discovery from the `issuer_url` if provided.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:**
Added unit test to check successful authorisation with direct JWKS URL
  - set a custom URL for the `issuer_url` to one not in the same domain as the JWKS URL.
  - Added parameter to `oidc_server` to disable the auto-discovery path to ensure it isn't used in the new test

**Documentation:** <Describe the documentation added.>

Signed-off-by: Richard Bain <richard@bain.id.au>